### PR TITLE
fix : pom.xml and CalculatorStep

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
 	<artifactId>calculator</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<properties>
-		<dep.junit.version>5.5.2</dep.junit.version>
-		<dep.cucumber.version>4.8.0</dep.cucumber.version>
+		<dep.junit.version>5.8.2</dep.junit.version>
+		<dep.cucumber.version>7.3.2</dep.cucumber.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
-		<bootstrap.version>4.3.1</bootstrap.version>
-		<springboot.version>2.2.0.RELEASE</springboot.version>
+		<bootstrap.version>5.1.3</bootstrap.version>
+		<springboot.version>2.6.6</springboot.version>
 	</properties>
 
 	<parent>
@@ -54,31 +54,42 @@
 			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.junit.vintage/junit-vintage-engine -->
 		<dependency>
 			<groupId>org.junit.vintage</groupId>
 			<artifactId>junit-vintage-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
 	
+		<!-- https://mvnrepository.com/artifact/io.cucumber/cucumber-jvm -->
 		<dependency>
-            <groupId>io.cucumber</groupId>
-            <artifactId>cucumber-jvm</artifactId>
-            <version>${dep.cucumber.version}</version>
-            <scope>test</scope>
-            <type>pom</type>
-        </dependency>
-        <dependency>
-            <groupId>io.cucumber</groupId>
-            <artifactId>cucumber-spring</artifactId>
-            <version>${dep.cucumber.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.cucumber</groupId>
-            <artifactId>cucumber-junit</artifactId>
-            <version>${dep.cucumber.version}</version>
-            <scope>test</scope>
-        </dependency>
+			<groupId>io.cucumber</groupId>
+			<artifactId>cucumber-jvm</artifactId>
+			<version>${dep.cucumber.version}</version>
+			<scope>test</scope>
+			<type>pom</type>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/io.cucumber/cucumber-java -->
+		<dependency>
+			<groupId>io.cucumber</groupId>
+			<artifactId>cucumber-java</artifactId>
+			<version>${dep.cucumber.version}</version>
+			<scope>test</scope>
+		</dependency>		
+		<!-- https://mvnrepository.com/artifact/io.cucumber/cucumber-spring -->
+		<dependency>
+			<groupId>io.cucumber</groupId>
+			<artifactId>cucumber-spring</artifactId>
+			<version>${dep.cucumber.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/io.cucumber/cucumber-junit -->
+		<dependency>
+			<groupId>io.cucumber</groupId>
+			<artifactId>cucumber-junit</artifactId>
+			<version>${dep.cucumber.version}</version>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-junit-jupiter</artifactId>
@@ -97,6 +108,12 @@
 			<groupId>javax.inject</groupId>
 			<artifactId>javax.inject</artifactId>
 			<version>1</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/javax.validation/validation-api -->
+		<dependency>
+			<groupId>javax.validation</groupId>
+			<artifactId>validation-api</artifactId>
+			<version>2.0.1.Final</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/src/test/java/com/openclassrooms/testing/calcul/acceptance/CalculatorSteps.java
+++ b/src/test/java/com/openclassrooms/testing/calcul/acceptance/CalculatorSteps.java
@@ -14,7 +14,10 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import io.cucumber.spring.CucumberContextConfiguration;
 
+
+@CucumberContextConfiguration
 @SpringBootTest
 @AutoConfigureMockMvc
 public class CalculatorSteps {


### PR DESCRIPTION
add annotation @CucumberContextConfiguration in CalculatorStep
to avoid :
io.cucumber.core.backend.CucumberBackendException: Please annotate a glue class with some context configuration.
For example:
   @CucumberContextConfiguration
   @SpringBootTest(classes = TestConfig.class)
   public class CucumberSpringConfiguration { }
Or:
   @CucumberContextConfiguration
   @ContextConfiguration( ... )
   public class CucumberSpringConfiguration { }

I update pom.xml in agreement with https://cucumber.io/docs/installation/java/ and for vulnerabilities in Log4j
